### PR TITLE
Fix windows 3.0, partially fix windows 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The ROM files are already included in the Windows build under the releases secti
 - i430FX and i430HX chipset support
 
 ##### Known working guest OSes:
+- Windows 3.0
 - Windows NT 4.0
 - Windows 2000 Professional and Server
 - Various Linux distributions

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -1122,10 +1122,7 @@ void cpu_intcall(CPU_t* cpu, uint8_t intnum, uint8_t source, uint32_t err) {
 	int frame_size;
 	int real_style_int;
 
-	real_style_int = !cpu->protected_mode ||
-		(cpu->v86f &&
-			((source == INT_SOURCE_SOFTWARE) || (source == INT_SOURCE_INT3) || (source == INT_SOURCE_INTO)) &&
-			(cpu->iopl >= 3));
+	real_style_int = !cpu->protected_mode;
 
 	if (real_style_int) { // real mode or VM86 software interrupt with IOPL >= 3
 		uint32_t real_flags = makeflagsword(cpu);
@@ -1817,7 +1814,7 @@ void op_ext_00(CPU_t* cpu) {
 			cpu->ldtl <<= 12;
 			cpu->ldtl |= 0xFFF;
 		}
-		cpu->ldtr = cpu_readw_sys(cpu, cpu->tempaddr32 + 2) | ((uint32_t)cpu_read_sys(cpu, cpu->tempaddr32 + 4) << 16) | (((uint32_t)cpu_read_sys(cpu, cpu->tempaddr32 + 7) >> 4) << 24);
+		cpu->ldtr = cpu_readw_sys(cpu, cpu->tempaddr32 + 2) | ((uint32_t)cpu_read_sys(cpu, cpu->tempaddr32 + 4) << 16) | ((uint32_t)cpu_read_sys(cpu, cpu->tempaddr32 + 7) << 24);
 		//debug_log(DEBUG_DETAIL, "Loaded LDT from %08X (LDT selector %04X (%04X), location is %08X, limit %u)", cpu->tempaddr32, cpu->ldt_selector, cpu->ldt_selector>>3, cpu->ldtr, cpu->ldtl);
 		break;
 	case 3: //LTR
@@ -4586,6 +4583,9 @@ void op_6B(CPU_t* cpu) {
 
 /* 6E INSB */
 void op_6C(CPU_t* cpu) {
+	if (!check_io_permission(cpu, cpu->regs.wordregs[regdx], 8)) 
+		return;
+
 	if (cpu->isaddr32) {
 		if (cpu->reptype && (cpu->regs.longregs[regecx] == 0)) {
 			return;
@@ -4643,6 +4643,9 @@ void op_6C(CPU_t* cpu) {
 
 /* 6D INSW */
 void op_6D(CPU_t* cpu) {
+	if (!check_io_permission(cpu, cpu->regs.wordregs[regdx], cpu->isoper32 ? 32 : 16)) 
+		return;
+
 	if (cpu->reptype) {
 		if (cpu->isaddr32) {
 			if (cpu->regs.longregs[regecx] == 0) return;
@@ -4701,6 +4704,9 @@ void op_6D(CPU_t* cpu) {
 
 /* 6E OUTSB */
 void op_6E(CPU_t* cpu) {
+	if (!check_io_permission(cpu, cpu->regs.wordregs[regdx], 8)) 
+		return;
+
 	if (cpu->reptype) {
 		if (cpu->isaddr32) {
 			if (cpu->regs.longregs[regecx] == 0) return;
@@ -4750,6 +4756,9 @@ void op_6E(CPU_t* cpu) {
 
 /* 6F OUTSW */
 void op_6F(CPU_t* cpu) {
+	if (!check_io_permission(cpu, cpu->regs.wordregs[regdx], cpu->isoper32 ? 32 : 16)) 
+		return;
+
 	if (cpu->reptype) {
 		if (cpu->isaddr32) {
 			if (cpu->regs.longregs[regecx] == 0) return;
@@ -6527,6 +6536,10 @@ void op_E3(CPU_t* cpu) {
 void op_E4(CPU_t* cpu) {
 	cpu->oper1b = getmem8(cpu, cpu->segcache[regcs], cpu->ip);
 	StepIP(cpu, 1);
+
+	if (!check_io_permission(cpu, cpu->oper1b, 8)) 
+		return;
+
 	cpu->regs.byteregs[regal] = (uint8_t)port_read(cpu, cpu->oper1b);
 }
 
@@ -6534,6 +6547,10 @@ void op_E4(CPU_t* cpu) {
 void op_E5(CPU_t* cpu) {
 	cpu->oper1b = getmem8(cpu, cpu->segcache[regcs], cpu->ip);
 	StepIP(cpu, 1);
+
+	if (!check_io_permission(cpu, cpu->oper1b, cpu->isoper32 ? 32 : 16)) 
+		return;
+
 	if (cpu->isoper32) {
 		cpu->regs.longregs[regeax] = port_readl(cpu, cpu->oper1b);
 	}
@@ -6546,6 +6563,10 @@ void op_E5(CPU_t* cpu) {
 void op_E6(CPU_t* cpu) {
 	cpu->oper1b = getmem8(cpu, cpu->segcache[regcs], cpu->ip);
 	StepIP(cpu, 1);
+
+	if (!check_io_permission(cpu, cpu->oper1b, 8)) 
+		return;
+
 	port_write(cpu, cpu->oper1b, cpu->regs.byteregs[regal]);
 }
 
@@ -6553,6 +6574,10 @@ void op_E6(CPU_t* cpu) {
 void op_E7(CPU_t* cpu) {
 	cpu->oper1b = getmem8(cpu, cpu->segcache[regcs], cpu->ip);
 	StepIP(cpu, 1);
+
+	if (!check_io_permission(cpu, cpu->oper1b, cpu->isoper32 ? 32 : 16)) 
+		return;
+
 	if (cpu->isoper32) {
 		port_writel(cpu, cpu->oper1b, cpu->regs.longregs[regeax]);
 	}
@@ -6628,12 +6653,20 @@ void op_EB(CPU_t* cpu) {
 /* EC IN cpu->regs.byteregs[regal] regdx */
 void op_EC(CPU_t* cpu) {
 	cpu->oper1 = cpu->regs.wordregs[regdx];
+
+	if (!check_io_permission(cpu, cpu->oper1, 8)) 
+		return;
+
 	cpu->regs.byteregs[regal] = (uint8_t)port_read(cpu, cpu->oper1);
 }
 
 /* ED IN eAX regdx */
 void op_ED(CPU_t* cpu) {
 	cpu->oper1 = cpu->regs.wordregs[regdx];
+
+	if (!check_io_permission(cpu, cpu->oper1, cpu->isoper32 ? 32 : 16)) 
+		return;
+
 	if (cpu->isoper32) {
 		cpu->regs.longregs[regeax] = port_readl(cpu, cpu->oper1);
 	}
@@ -6645,12 +6678,20 @@ void op_ED(CPU_t* cpu) {
 /* EE OUT regdx cpu->regs.byteregs[regal] */
 void op_EE(CPU_t* cpu) {
 	cpu->oper1 = cpu->regs.wordregs[regdx];
+
+	if (!check_io_permission(cpu, cpu->oper1, 8)) 
+		return;
+
 	port_write(cpu, cpu->oper1, cpu->regs.byteregs[regal]);
 }
 
 /* EF OUT regdx eAX */
 void op_EF(CPU_t* cpu) {
 	cpu->oper1 = cpu->regs.wordregs[regdx];
+
+	if (!check_io_permission(cpu, cpu->oper1, cpu->isoper32 ? 32 : 16)) 
+		return;
+
 	if (cpu->isoper32) {
 		port_writel(cpu, cpu->oper1, cpu->regs.longregs[regeax]);
 	}

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -1120,11 +1120,8 @@ void cpu_intcall(CPU_t* cpu, uint8_t intnum, uint8_t source, uint32_t err) {
 	int has_err;
 	int include_vm86;
 	int frame_size;
-	int real_style_int;
 
-	real_style_int = !cpu->protected_mode;
-
-	if (real_style_int) { // real mode or VM86 software interrupt with IOPL >= 3
+	if (!cpu->protected_mode) { // real mode
 		uint32_t real_flags = makeflagsword(cpu);
 		uint16_t target_cs;
 		uint16_t target_ip;

--- a/src/cpu/cpuhelper.h
+++ b/src/cpu/cpuhelper.h
@@ -852,6 +852,25 @@ static void task_switch(CPU_t* cpu, uint16_t new_tss_selector, int reason) {
 	}
 }
 
+// IO read/writes check permission in pmode as well as V86
+static FUNC_FORCE_INLINE int check_io_permission(CPU_t* cpu, uint16_t port, int size) {
+	if (cpu->v86f || (cpu->protected_mode && cpu->cpl > cpu->iopl)) {
+		uint16_t io_map_base = cpu_readw_sys(cpu, cpu->trbase + 102);
+		for (int i = 0; i < (size / 8); i++) {
+			uint16_t cur_port = port + i;
+			if ((io_map_base + (cur_port >> 3)) >= cpu->trlimit) {
+				exception(cpu, 13, 0);
+				return 0;
+			}
+			if (cpu_read_sys(cpu, cpu->trbase + io_map_base + (cur_port >> 3)) & (1 << (cur_port & 7))) {
+				exception(cpu, 13, 0);
+				return 0;
+			}
+		}
+	}
+	return 1;
+}
+
 static void modregrm(CPU_t* cpu) {
 	cpu->addrbyte = getmem8(cpu, cpu->segcache[regcs], cpu->ip);
 	StepIP(cpu, 1);


### PR DESCRIPTION
Changes:
Implement IO permission checks
Fix to LLDT
Change to real_style_int

Notes:
Without the LLDT and real_style_int changes (both of them) windows 3.0 doesnt want to start although i am not sure what the original purpose of the real_style_int was and if i broke something by changing it, for now it doesnt seem to of broken anything.

It should be verified that all the OSes that ran before still work, i have tested some things and they seem to still work but i have not verified that nt4/win 2000 still work so im unsure if my changes broke anything.

Windows 3.1 does NOT work yet, i have verified and while it gets further it seems to get stuck, im not exactly sure what the cause of windows 3.1 not working is, it gets stuck in a loop after getting through the boot splashscreen but it doesnt freeze completely as the mouse is still moveable.

Since these changes fixed some things it might lead to some fixes in windows 9x but i currently have not tried 9x yet to see if it fixed anything there.

Screenshots:
Windows 3.0
<img width="637" height="502" alt="image" src="https://github.com/user-attachments/assets/58124c76-4f4a-4ae4-86b9-b9c123ac0bfb" />

Windows 3.1 (Showing the current bug not allowing it to finish boot)
<img width="639" height="508" alt="image" src="https://github.com/user-attachments/assets/b00cf8d0-aa12-4600-8615-513f707a53b8" />